### PR TITLE
Fix the pubdate field to pubDate

### DIFF
--- a/site/lib/erlangelist/web/blog/templates/rss.xml.eex
+++ b/site/lib/erlangelist/web/blog/templates/rss.xml.eex
@@ -8,7 +8,7 @@
       <item>
         <title><![CDATA[<%= article.title %>]]></title>
         <link><![CDATA[http://theerlangelist.com/<%= article.link %>]]></link>
-        <pubdate><%= article.posted_at_rfc822 %></pubdate>
+        <pubDate><%= article.posted_at_rfc822 %></pubDate>
         <description>
           <![CDATA[<%= Phoenix.View.render_to_string(__MODULE__, "_article_content.html", article: article) %>]]>
         </description>


### PR DESCRIPTION
As per https://www.w3schools.com/XML/rss_tag_pubdate_item.asp, the pub date attribute is pubDate. 

The all lowercase form isn't properly parsed with rss parsers like https://github.com/michaelnisi/feeder. Namely, this line shows that it's looking for standard rss attributes: https://github.com/michaelnisi/feeder/blob/de2004cb954a5a70390a680e2cb0ed697dfcfd27/src/feeder_elements.erl#L62. As a result, your posts have no timestamp in the parsed rss feed.